### PR TITLE
GH #1: experimental attempt for quoted evals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: perl
+perl:
+  - "5.8"
+  - "5.10"
+  - "5.12"
+  - "5.14"
+  - "5.16"
+  - "5.18"
+  - "5.20"
+  - "5.22"
+  - "5.24"
+  - "5.26"
+  - "5.28"
+  - "blead"
+sudo: false
+matrix:
+  fast_finish: true
+  include:
+    - perl: 5.26
+      env: COVERAGE=1
+  allow_failures:
+    - perl: blead
+before_install:
+  - eval $(curl https://travis-perl.github.io/init) --auto
+branches:
+  except:
+    - /^wip\//
+    - /^blocked/
+    - /^issue\d+/
+    - /^gh\d+/

--- a/dist.ini
+++ b/dist.ini
@@ -45,7 +45,9 @@ List::Util = 0
 
 ; -- test requirements
 [Prereqs / TestRequires]
-Test::More = 0.92
+Test::More              = 0.92
+Test::EOL               = 0
+Pod::Coverage::TrustPod = 0
 
 ; for maintainers, see with mst how to avoid these
 ; strictures = 0

--- a/lib/Ref/Util/Rewriter.pm
+++ b/lib/Ref/Util/Rewriter.pm
@@ -34,8 +34,10 @@ sub rewrite_file {
 }
 
 sub rewrite_doc {
-    my $doc            = shift;
+    my $doc            = shift or die;
     my $all_statements = $doc->find('PPI::Statement');
+    $all_statements    = [] unless defined $all_statements;
+
     my @cond_ops       = qw<or || and &&>;
     my @new_statements;
 
@@ -45,6 +47,67 @@ sub rewrite_doc {
         # causing duplication in results
         $statement->$_isa('PPI::Statement::Compound')
             and next;
+
+        my $evals = $statement->find(
+            sub {
+                $_[1]->isa('PPI::Token::Word') and $_[1]->content eq 'eval';
+            }
+        ) || [];
+
+        foreach my $eval (@$evals) {
+            my $sib = $eval;
+            while ( $sib = $sib->next_sibling ) {
+                if ( $sib->isa('PPI::Token::Quote') ) {
+                    last unless $sib->content =~ qr{\bref\b};    # shortcut
+                         # '' - PPI::Token::Quote::Single
+                         # "q{}" - PPI::Token::Quote::Literal
+                         # "" - PPI::Token::Quote::Double
+                         # "qq{}" - PPI::Token::Quote::Interpolate
+                    my ( $content, $after, $before );
+                    my $sib_class = ref $sib;
+                    if ( $sib->isa('PPI::Token::Quote::Single') ) {
+                        $after = $before = q{'};
+                        $content = $sib->literal;
+                    }
+                    elsif ( $sib->isa('PPI::Token::Quote::Double') ) {
+                        $after = $before = q{"};
+                        $content = $sib->string;
+                    }
+                    elsif ( $sib->isa('PPI::Token::Quote::Literal') ) {
+                        $before = 'q{';
+                        $after  = '}';
+                        if ( $sib->content =~ qr{^q(.).*(.)$} ) {
+                            $before = 'q' . $1;
+                            $after  = $2;
+                        }
+                        $content = $sib->literal;
+                    }
+                    elsif ( $sib->isa('PPI::Token::Quote::Interpolate') ) {
+                        $before = 'qq{';
+                        $after  = '}';
+                        if ( $sib->string =~ qr{^q(.).*(.)$} ) {
+                            $before = $1;
+                            $after  = $2;
+                        }
+
+                        $content = $sib->string;
+                    }
+                    next unless $content;
+
+                    # FIXME: this is very ugly....
+                    # FIXME need to escape for literals but the idea is there
+                    $sib->{content} =
+                      $before . rewrite_string($content) . $after;
+
+           # Idea:
+           # my $p = PPI::Token::Quote::Double->new( rewrite_string($content) );
+           # $sib->insert_before( $p );
+           # $sib->delete;
+                    last;
+                }
+            }
+
+        }
 
         # find the 'ref' functions
         my $ref_subs = $statement->find( sub {


### PR DESCRIPTION
This commit is not complete but here as proof of concept/attempt, and will work for the most basic cases.
The content read from literal should be escaped correctly, once updated

PPI::Token::Quote::\* API is fuzzy and the tricky part is to replace the element
this can be done by `$sib->insert_before( $p ); $sib->delete` but the creation of the element is not trivial.

```
# '' - PPI::Token::Quote::Single
# "q{}" - PPI::Token::Quote::Literal
# "" - PPI::Token::Quote::Double
# "qq{}" - PPI::Token::Quote::Interpolate
```

Maybe use the internal of the PPI Quote element ?
