### PR TITLE
[::Rewriter] use "our" for @EXPORT_OK

### DIFF
--- a/lib/Ref/Util/Rewriter.pm
+++ b/lib/Ref/Util/Rewriter.pm
@@ -9,7 +9,7 @@ use Safe::Isa;
 use Exporter   qw< import >;
 use List::Util qw< first  >;
 
-my @EXPORT_OK = qw< rewrite_string rewrite_file >;
+our @EXPORT_OK = qw< rewrite_string rewrite_file >;
 
 my %reftype_to_reffunc = (
     SCALAR => 'is_scalarref',


### PR DESCRIPTION
fixes the SYNOPSIS example:

```
➤ perl -lE'use Ref::Util::Rewriter qw<rewrite_file>'
"rewrite_file" is not exported by the Ref::Util::Rewriter module
Can't continue after import errors at -e line 1.
BEGIN failed--compilation aborted at -e line 1.
```
