### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: perl
+perl:
+  - "5.8"
+  - "5.10"
+  - "5.12"
+  - "5.14"
+  - "5.16"
+  - "5.18"
+  - "5.20"
+  - "5.22"
+  - "5.24"
+  - "5.26"
+  - "5.28"
+  - "blead"
+sudo: false
+matrix:
+  fast_finish: true
+  include:
+    - perl: 5.26
+      env: COVERAGE=1
+  allow_failures:
+    - perl: blead
+before_install:
+  - eval $(curl https://travis-perl.github.io/init) --auto
+branches:
+  except:
+    - /^wip\//
+    - /^blocked/
+    - /^issue\d+/
+    - /^gh\d+/

--- a/dist.ini
+++ b/dist.ini
@@ -45,7 +45,9 @@ List::Util = 0
 
 ; -- test requirements
 [Prereqs / TestRequires]
-Test::More = 0.92
+Test::More              = 0.92
+Test::EOL               = 0
+Pod::Coverage::TrustPod = 0
 
 ; for maintainers, see with mst how to avoid these
 ; strictures = 0


### PR DESCRIPTION
provide a basic travis.yaml configuration file and add missing test dependencies to smoke on Travis CI.