### PR TITLE
rewrite_file overwrite previous content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: perl
+perl:
+  - "5.8"
+  - "5.10"
+  - "5.12"
+  - "5.14"
+  - "5.16"
+  - "5.18"
+  - "5.20"
+  - "5.22"
+  - "5.24"
+  - "5.26"
+  - "5.28"
+  - "blead"
+sudo: false
+matrix:
+  fast_finish: true
+  include:
+    - perl: 5.26
+      env: COVERAGE=1
+  allow_failures:
+    - perl: blead
+before_install:
+  - eval $(curl https://travis-perl.github.io/init) --auto
+branches:
+  except:
+    - /^wip\//
+    - /^blocked/
+    - /^issue\d+/
+    - /^gh\d+/

--- a/dist.ini
+++ b/dist.ini
@@ -45,7 +45,9 @@ List::Util = 0
 
 ; -- test requirements
 [Prereqs / TestRequires]
-Test::More = 0.92
+Test::More              = 0.92
+Test::EOL               = 0
+Pod::Coverage::TrustPod = 0
 
 ; for maintainers, see with mst how to avoid these
 ; strictures = 0

--- a/dist.ini
+++ b/dist.ini
@@ -48,6 +48,8 @@ List::Util = 0
 Test::More              = 0.92
 Test::EOL               = 0
 Pod::Coverage::TrustPod = 0
+File::Temp              = 0
+File::Slurper           = 0
 
 ; for maintainers, see with mst how to avoid these
 ; strictures = 0

--- a/lib/Ref/Util/Rewriter.pm
+++ b/lib/Ref/Util/Rewriter.pm
@@ -39,15 +39,13 @@ sub rewrite_doc {
     my @cond_ops       = qw<or || and &&>;
     my @new_statements;
 
+    ALL_STATEMENTS:
     foreach my $statement ( @{$all_statements} ) {
         # if there's an "if()" statement, it appears as a Compound statement
         # and then each internal statement appears again,
         # causing duplication in results
         $statement->$_isa('PPI::Statement::Compound')
             and next;
-
-        # avoid a bug in PPI after removal
-        last unless $statement->{children};
 
         # find the 'ref' functions
         my $ref_subs = $statement->find( sub {
@@ -171,6 +169,11 @@ sub rewrite_doc {
             }
 
             $ref_sub->remove;
+
+            # update statements... to avoid PPI issues when moving elements...
+            # this is very ugly... but probably the best solution
+            $all_statements = $doc->find('PPI::Statement');
+            goto ALL_STATEMENTS;
         }
     }
 

--- a/lib/Ref/Util/Rewriter.pm
+++ b/lib/Ref/Util/Rewriter.pm
@@ -30,7 +30,16 @@ sub rewrite_string {
 
 sub rewrite_file {
     my $file = shift;
-    return rewrite_doc( PPI::Document->new($file) );
+    my $content = rewrite_doc( PPI::Document->new($file) );
+
+    {
+        # replace file content
+        open( my $fh, '>', $file ) or die "Failed to open file $file: $!";
+        print {$fh} $content;
+        close $fh;
+    }
+
+    return $content;
 }
 
 sub rewrite_doc {

--- a/t/rewrite.t
+++ b/t/rewrite.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 2 + 6;
+use Test::More tests => 2 + 8;
 
 BEGIN {
     use_ok('Ref::Util::Rewriter');
@@ -18,6 +18,8 @@ my @tests = (
     q{ref($foo) or}                => q{is_ref($foo) or},
     q!if (ref($foo) eq 'ARRAY') {! => q!if (is_arrayref($foo)) {!,
     q{ref($foo) eq 'ARRAY' or}     => q{is_arrayref($foo) or},
+    q!sub { my $is_arrayref = ref $self eq 'ARRAY'; }! => q!sub { my $is_arrayref = is_arrayref($self); }!,
+    q!sub { my $is_arrayref = ref $self eq 'ARRAY' && $x == 42; }! => q!sub { my $is_arrayref = is_arrayref($self) && $x == 42; }!,
 
     # not supported (yet?)
     #qq{ref(\$foo) # comment\nor}   => q{is_ref($foo) or # comment},

--- a/t/rewrite.t
+++ b/t/rewrite.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 2 + 8;
+use Test::More tests => 2 + 11;
 
 BEGIN {
     use_ok('Ref::Util::Rewriter');
@@ -13,6 +13,8 @@ can_ok(
 
 my @tests = (
     q{ref $foo eq 'ARRAY';}        => q{is_arrayref($foo);},
+    q{ref $foo eq 'CODE';}        => q{is_coderef($foo);},
+    q{ref $foo eq 'CODE' && ref $foo eq 'ARRAY';}        => q{is_coderef($foo) && is_arrayref($foo);},
     q{ref($foo) eq 'ARRAY';}       => q{is_arrayref($foo);},
     q{ref  ($foo) eq 'ARRAY';}     => q{is_arrayref($foo);},
     q{ref($foo) or}                => q{is_ref($foo) or},
@@ -20,6 +22,7 @@ my @tests = (
     q{ref($foo) eq 'ARRAY' or}     => q{is_arrayref($foo) or},
     q!sub { my $is_arrayref = ref $self eq 'ARRAY'; }! => q!sub { my $is_arrayref = is_arrayref($self); }!,
     q!sub { my $is_arrayref = ref $self eq 'ARRAY' && $x == 42; }! => q!sub { my $is_arrayref = is_arrayref($self) && $x == 42; }!,
+    q!sub {return ref($self) eq 'CODE'; }! => q!sub {return is_coderef($self); }!,
 
     # not supported (yet?)
     #qq{ref(\$foo) # comment\nor}   => q{is_ref($foo) or # comment},

--- a/t/rewrite_file.t
+++ b/t/rewrite_file.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+use File::Temp qw/ tempdir /;
+use File::Slurper qw/ read_text write_text /;
+
+use Ref::Util::Rewriter qw/ rewrite_file /;
+
+my $tmp = tempdir( CLEANUP => 1 );
+my $test_pm = "$tmp/MyPackage.pm";
+
+write_text( $test_pm, <<'CONTENT' );
+package MyPackage;
+
+sub run {
+    my $do = shift;
+    $do->() f ref $do eq 'CODE';
+}
+CONTENT
+
+my $expect = <<'EXPECT';
+package MyPackage;
+
+sub run {
+    my $do = shift;
+    $do->() f is_coderef($do);
+}
+EXPECT
+
+is rewrite_file($test_pm), $expect, "preserve original behavior...";
+is read_text($test_pm),    $expect, "File was updated...";


### PR DESCRIPTION

    Pod mention that 'rewrite_file' "rewrite the file in place"
    but obsiously it does not and simply return the updated content
    instead.

    This commit is adding a unit test and fixes 'rewrite_file' by
    preserving the original behavior of returning the updated content.
    (instead of a boolean as we could expect)